### PR TITLE
Adjust gain slider to use native volume below 100%

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -207,9 +207,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const applyGainFromSlider = (value) => {
     const normalized = clamp(Number(value) / 100, 0, 2);
     if (!useNativeVolume && gainNode) {
-      gainNode.gain.value = normalized;
-      if (audioElement.volume !== 0) {
-        audioElement.volume = 0;
+      if (normalized <= 1) {
+        audioElement.volume = normalized;
+        gainNode.gain.value = 1;
+      } else {
+        audioElement.volume = 1;
+        gainNode.gain.value = normalized;
       }
     } else {
       const fallbackVolume = clamp(normalized, 0, 1);


### PR DESCRIPTION
## Summary
- update the gain slider logic to rely on the audio element volume up to 100%
- only apply extra amplification via the GainNode when the slider exceeds 100%

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb670555448331a2f95af4fc8ed7c2